### PR TITLE
FIX: Version of recipe for 4.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "type": "silverstripe-vendormodule",
     "license": "BSD-3-Clause",
     "require": {
-        "silverstripe/recipe-cms": "^1.0",
+        "silverstripe/recipe-cms": "^1.0 || ^4.0",
         "silverstripe/vendor-plugin": "^1.0",
         "dnadesign/silverstripe-elemental": "^2.0",
         "symbiote/silverstripe-gridfieldextensions": "^3.0"


### PR DESCRIPTION
The version of recipe-cms effectively pinned this repo to 4.1 when I tried to upgrade.  Not sure if this is the best way to fix it, and it will need a major version bump in packagist as it's not backwards compatible to 4.1.