### PR TITLE
REFACTOR: Remove getType() override to allow extensibility (SS5)

### DIFF
--- a/src/Elements/ElementTestimonials.php
+++ b/src/Elements/ElementTestimonials.php
@@ -34,7 +34,7 @@ class ElementTestimonials extends BaseElement
     /**
      * @var string
      */
-    private static $plural_name = 'Testimonials Blocks';
+    private static $plural_name = 'Testimonials';
 
     /**
      * @var string

--- a/src/Elements/ElementTestimonials.php
+++ b/src/Elements/ElementTestimonials.php
@@ -29,12 +29,12 @@ class ElementTestimonials extends BaseElement
     /**
      * @var string
      */
-    private static $singular_name = 'Testimonials Element';
+    private static $singular_name = 'Testimonials';
 
     /**
      * @var string
      */
-    private static $plural_name = 'Testimonials Elements';
+    private static $plural_name = 'Testimonials Blocks';
 
     /**
      * @var string
@@ -93,14 +93,6 @@ class ElementTestimonials extends BaseElement
         $blockSchema = parent::provideBlockSchema();
         $blockSchema['content'] = $this->getSummary();
         return $blockSchema;
-    }
-
-    /**
-     * @return string
-     */
-    public function getType()
-    {
-        return _t(__CLASS__ . '.BlockType', 'Testimonials');
     }
 
     /**


### PR DESCRIPTION
## Summary

Remove the `getType()` method override so the element inherits `BaseElement::getType()` which uses `i18n_singular_name()`. This allows sites to customize the element's display name via extensions by setting `$singular_name`.

## Changes

- Removed the `getType()` method from `ElementTestimonials`
- Updated `$singular_name` from `'Testimonials Element'` to `'Testimonials'`
- Updated `$plural_name` from `'Testimonials Elements'` to `'Testimonials Blocks'`

## Rationale

The base `BaseElement::getType()` implementation already uses `$this->i18n_singular_name()`:

```php
public function getType()
{
    $default = $this->i18n_singular_name() ?: 'Block';
    return _t(static::class . '.BlockType', $default);
}
```

By removing the override, extensions can now customize the display name in the CMS element picker by simply setting `$singular_name`, without needing to override the entire method.

Fixes #31

Related: dynamic/silverstripe-essentials-tools#68