### PR TITLE
fix(#35): remove getType() override, rename singular/plural names

### DIFF
--- a/src/Elements/ElementTestimonials.php
+++ b/src/Elements/ElementTestimonials.php
@@ -29,12 +29,12 @@ class ElementTestimonials extends BaseElement
     /**
      * @var string
      */
-    private static $singular_name = 'Testimonials Element';
+    private static $singular_name = 'Testimonials';
 
     /**
      * @var string
      */
-    private static $plural_name = 'Testimonials Elements';
+    private static $plural_name = 'Testimonials Blocks';
 
     /**
      * @var string
@@ -93,14 +93,6 @@ class ElementTestimonials extends BaseElement
         $blockSchema = parent::provideBlockSchema();
         $blockSchema['content'] = $this->getSummary();
         return $blockSchema;
-    }
-
-    /**
-     * @return string
-     */
-    public function getType()
-    {
-        return _t(__CLASS__ . '.BlockType', 'Testimonials');
     }
 
     /**


### PR DESCRIPTION
## Summary

- Remove deprecated `getType()` override (SS6 removes `BaseElement::getDescription()`/`getType()` path)
- Rename `$singular_name` from `'Testimonials Element'` → `'Testimonials'`
- Rename `$plural_name` from `'Testimonials Elements'` → `'Testimonials Blocks'`

Closes #35

## Test plan

- [ ] `ddev sake dev/build flush=1` exits 0 with "Database build completed!"
- [ ] CI passes (phplinting, phpunit)